### PR TITLE
Generalise README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright (C) Genymobile
 
 ## Description
 
-This repository stores Genymotion Android development and release keys, and corresponding .mk that we include internally in our `device.mk`. Third party  developpers can use the release keys to sign their own applications in order to grant them system privileges.
+This repository stores Genymotion Android development and release keys, and corresponding .mk that we include internally in our `device.mk`. Third party developpers can use the release keys to sign their own applications in order to grant them system privileges on Genymotion. Only our Android 10 version rely on these keys for now.
 
 `dev-keys` are used in `device.mk` to sign the system at build (properties are flagged with dev-keys).
 We use `dev-keys/testkey`, but the build system flags them as `dev-keys`, as they are not the default AOSP keys.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Copyright (C) Genymobile
 
 ## Description
 
-This repository stores Genymotion Android development and release keys, and corresponding .mk that are included from device.mk.
+This repository stores Genymotion Android development and release keys, and corresponding .mk that we include internally in our `device.mk`. Third party  developpers can use the release keys to sign their own applications in order to grant them system privileges.
 
 `dev-keys` are used in `device.mk` to sign the system at build (properties are flagged with dev-keys).
 We use `dev-keys/testkey`, but the build system flags them as `dev-keys`, as they are not the default AOSP keys.
@@ -15,13 +15,15 @@ See: https://android.googlesource.com/platform/build/+/refs/tags/android-10.0.0_
 
 ## Key generation
 
-In the Genymotion Android root source : 
+This part is for internal use. It describes our procedure to generate the development and release keys.
+
+In the Genymotion Android root source: 
 
 ```
 $ subject='/C=FR/ST=Seine/L=Paris/O=Genymobile/OU=Genymotion/CN=Genymobile/emailAddress=contact@genymotion.com'
 ```
 
-Generate dev keys : 
+Generate dev keys: 
 
 ```
 $ for x in testkey platform shared media networkstack; do \
@@ -29,7 +31,7 @@ $ for x in testkey platform shared media networkstack; do \
 done
 ```
 
-Generate release keys : 
+Generate release keys: 
 
 ```
 $ for x in releasekey platform shared media networkstack; do \

--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
-# Genymotion dev and release keys.
+# Genymotion development and release keys
 
 Copyright (C) Genymobile
 
 ## Description
 
-Repository to store dev and release keys, and corresponding .mk that are included from device.mk.
+This repository stores Genymotion Android development and release keys, and corresponding .mk that are included from device.mk.
 
-dev-keys/ is used in device/genymotion/vbox86/device.mk to sign the system at build (properties are flagged with dev-keys).
-We use dev-keys/testkey, but the build system flag for dev-keys, as they are not the AOSP default keys.
-See : https://android.googlesource.com/platform/build/+/refs/tags/android-10.0.0_r25/core/Makefile#306
+`dev-keys` are used in `device.mk` to sign the system at build (properties are flagged with dev-keys).
+We use `dev-keys/testkey`, but the build system flags them as `dev-keys`, as they are not the default AOSP keys.
 
-release-keys/ is used with signature script to resign as release (properties are flagged with release-keys, apk are resigned).
+See: https://android.googlesource.com/platform/build/+/refs/tags/android-10.0.0_r25/core/Makefile#306
+
+`release-keys` are used by signature script to re-sign the build as a release one. Properties are flagged as `release-keys`, apk files are re-signed.
 
 ## Key generation
 
@@ -36,15 +37,15 @@ $ for x in releasekey platform shared media networkstack; do \
 done
 ```
 
-## Genymotion Keystore :
+## Genymotion Keystore
 
 ### Generate the keystore
 
-To sign an application APK with the release keys, gradle/Android Studio need a keystore.
-For debug builds, a default keystore $HOME/.android/debug.keystore is useD.
+To sign an application APK with the release keys, gradle/Android Studio needs a keystore.
+For debug builds, a default `$HOME/.android/debug.keystore` keystore is used.
 For release builds, we can specify another keystore generated from our release keys.
 
-How to generate the release keystore in the directory release-keys/keystore : 
+How to generate the release keystore in the directory `release-keys/keystore`: 
 
 ```
 $ openssl pkcs8 -inform DER -nocrypt -in ../platform.pk8 | \
@@ -59,12 +60,10 @@ $ rm platform_release.pem
 
 ### Use the keystore
 
-The generated keystore (platform_release.keystore) can now be used to build and sign Android application.
+The generated keystore (platform_release.keystore) can now be used to sign Android applications.
 
-Example for genymotion-testing/GenymotionTestReleaseKey : 
-* Copy platform_release.keystore in genymotion-testing/GenymotionTestReleaseKey/app/platform_release.keystore
-genymotion-testing/GenymotionTestReleaseKey
-* Update build.gradle file to use this keystore : 
+* Copy `platform_release.keystore` into your application sources: `<project>/app/platform_release.keystore`.
+* Update your `build.gradle` file to use this keystore: 
 
 ```
 android {
@@ -95,5 +94,4 @@ android {
         }
     }
 }
-
 ```


### PR DESCRIPTION
Now that this repository is public, we can make the README.md more generic to make it clearer for third-party developers.